### PR TITLE
Bind on localhost IP only

### DIFF
--- a/lib/jedi-python2-complete.py
+++ b/lib/jedi-python2-complete.py
@@ -47,7 +47,7 @@ class http_completion(BaseHTTPRequestHandler):
 
 def run_server():
     """run the httpd"""
-    address = ('', 7777)
+    address = ('127.0.0.1', 7777)
 
     while True:
         try:

--- a/lib/jedi-python3-complete.py
+++ b/lib/jedi-python3-complete.py
@@ -49,7 +49,7 @@ class http_completion(BaseHTTPRequestHandler):
 
 def run_server():
     """run the httpd"""
-    address = ('', 7777)
+    address = ('127.0.0.1', 7777)
 
     while True:
         try:


### PR DESCRIPTION
`python-jedi` binds without specifying an IP address, which means that everyone can connect to it and make requests on it. This is a **huge security issue**.

This branch fixes the issue by specifying that `python-jedi` should only listen to localhost IP `127.0.0.1`.